### PR TITLE
mysql driver: escape tableName

### DIFF
--- a/Driver/MySQL.php
+++ b/Driver/MySQL.php
@@ -20,7 +20,7 @@ class MySQL extends Driver
 
     public function makeIndexes(): string
     {
-        $sql = "show index from {$this->tableName} from {$this->database} where key_name <> 'PRIMARY'";
+        $sql = "show index from `{$this->tableName}` from {$this->database} where key_name <> 'PRIMARY'";
         $rs = $this->connection->fetchAllAssociative($sql);
         if (empty($rs)) {
             return "";


### PR DESCRIPTION
Hey there! 

Thanks a lot for your tool, it worked perfectly, I've just had to modify this little line because I had a table named `system` and I guess it's a keyword in Mysql so it has to be escaped.

Hope it helps, have a good day!